### PR TITLE
Resolves AttributeError with TensorFlow 2.4.1

### DIFF
--- a/tfviewer.py
+++ b/tfviewer.py
@@ -83,7 +83,7 @@ def preload_images(max_images):
 
   for tfrecord_path in args.tfrecords:
     print("Filename: ", tfrecord_path)
-    for i, record in enumerate(tf.python_io.tf_record_iterator(tfrecord_path)):
+    for i, record in enumerate(tf.compat.v1.python_io.tf_record_iterator(tfrecord_path)):
       if args.verbose: print("######################### Record", i, "#########################")
       example = tf.train.Example()
       example.ParseFromString(record)


### PR DESCRIPTION
I'm running TensorFlow 2.4.1.  When I first ran tfrecord-viewer, it presented the following error:
`AttributeError: module 'tensorflow' has no attribute 'python_io'
`

I came across this solution in another project, https://github.com/datitran/raccoon_dataset/issues/90

It now runs without issue - I'm not sure what the impact might be to older versions of Tensorflow.