### PR TITLE
Change "attachment_filename" to "download_name"

### DIFF
--- a/tfviewer.py
+++ b/tfviewer.py
@@ -171,7 +171,7 @@ def get_image(key):
   img = images[key]
   img_buffer = io.BytesIO(img)
   return send_file(img_buffer,
-                   attachment_filename=str(key)+'.jpeg',
+                   download_name=str(key)+'.jpeg',
                    mimetype='image/jpg')
 
 @app.after_request


### PR DESCRIPTION
Resolves #19. Variable `attachment_filename` has been renamed `download_name` as mentioned in this [Stack Overflow thread](https://stackoverflow.com/questions/73276384/getting-an-error-attachment-filename-does-not-exist-in-my-docker-environment).